### PR TITLE
Template resolved.conf instead of sedding

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,9 +55,18 @@ if node['consul']['use_dnsmasq'].casecmp?("true")
                     iptables -t nat -A OUTPUT -d localhost -p tcp -m tcp --dport 53 -j REDIRECT --to-ports 8600
                     iptables-save | tee /etc/iptables/rules.v4
                     ip6tables-save | sudo tee /etc/iptables/rules.v6
-                    sed -i "s/#DNS=/DNS=#{dnsmasq_ip}/g" /etc/systemd/resolved.conf
-                    sed -i "s/#Domains=/Domains=~#{node['consul']['domain']}/g" /etc/systemd/resolved.conf
                 EOH
+            end
+
+            template '/etc/systemd/resolved.conf' do
+                source 'resolved.conf.erb'
+                owner 'root'
+                group 'root'
+                mode '0755'
+                action :create
+                variables ({
+                    :dnsmasq_ip => dnsmasq_ip,
+                })
             end
 
             if node['install']['localhost'].casecmp?("true")

--- a/templates/default/resolved.conf.erb
+++ b/templates/default/resolved.conf.erb
@@ -1,0 +1,22 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See resolved.conf(5) for details
+
+[Resolve]
+DNS=<%= @dnsmasq_ip %>
+#FallbackDNS=
+Domains=<%= node['consul']['domain'] %>
+#LLMNR=no
+#MulticastDNS=no
+#DNSSEC=yes
+#Cache=yes
+#DNSStubListener=yes

--- a/templates/default/resolved.conf.erb
+++ b/templates/default/resolved.conf.erb
@@ -14,7 +14,7 @@
 [Resolve]
 DNS=<%= @dnsmasq_ip %>
 #FallbackDNS=
-Domains=<%= node['consul']['domain'] %>
+Domains=~<%= node['consul']['domain'] %>
 #LLMNR=no
 #MulticastDNS=no
 #DNSSEC=yes


### PR DESCRIPTION
On the new KVM images, the `resolved.conf` is already configured. It's configured in such a way that the sed rules don't match. 
We should template the configuration file instead.