### PR TITLE
[HWORKS-649] Use log files for Consul and dnsmasq instead of stdout/systemd

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,10 +3,20 @@ default['consul']['user_id']                    = '1500'
 default['consul']['group']                      = node['install']['user'].empty? ? 'consul' : node['install']['user']
 default['consul']['group_id']                   = '1500'
 default['consul']["dir"]                        = node['install']['dir'].empty? ? "/srv/hops" : node['install']['dir']
+
+default['consul']['data_volume']['root_dir']    = "#{node['data']['dir']}/consul"
+default['consul']['data_volume']['logs_dir']    = "#{node['consul']['data_volume']['root_dir']}/logs"
+
+default['dnsmasq']['data_volume']['root_dir']   = "#{node['data']['dir']}/dnsmasq"
+default['dnsmasq']['data_volume']['logs_dir']   = "#{node['dnsmasq']['data_volume']['root_dir']}/logs"
+default['dnsmasq']['home']                      = "#{node['consul']['dir']}/dnsmasq"
+default['dnsmasq']['logs_dir']                  = "#{node['dnsmasq']['home']}/logs"
+
 default['consul']['home']                       = "#{node['consul']['dir']}/consul"
 default['consul']['conf_dir']                   = "#{node['consul']['home']}/consul.d"
 default['consul']['data_dir']                   = "#{node['consul']['home']}/data_dir"
 default['consul']['bin_dir']                    = "#{node['consul']['home']}/bin"
+default['consul']['logs_dir']                   = "#{node['consul']['home']}/logs"
 
 default['consul']['version']                    = "1.7.0"
 default['consul']['bin_url']                    = "#{node['download_url']}/consul/consul_#{node['consul']['version']}_linux_amd64.zip"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,8 +1,50 @@
+directory node['consul']['data_volume']['root_dir'] do
+    owner node['consul']['user']
+    group node['consul']['group']
+    mode "0750"
+    action :create
+end
+
+directory node['consul']['data_volume']['logs_dir'] do
+    owner node['consul']['user']
+    group node['consul']['group']
+    mode "0750"
+    action :create
+end
+
+link node['consul']['logs_dir'] do
+    owner node['consul']['user']
+    group node['consul']['group']
+    mode "0750"
+    to node['consul']['data_volume']["logs_dir"]
+end
+
 # Install and configure dnsmasq
 if node['consul']['use_dnsmasq'].casecmp?("true")
     package 'dnsmasq' do
         retries 10
         retry_delay 30
+    end
+
+    directory node['dnsmasq']['data_volume']['root_dir'] do
+        owner 'root'
+        group 'root'
+        mode "0750"
+        action :create
+    end
+    
+    directory node['dnsmasq']['data_volume']['logs_dir'] do
+        owner 'root'
+        group 'root'
+        mode "0750"
+        action :create
+    end
+    
+    link node['dnsmasq']['logs_dir'] do
+        owner 'root'
+        group 'root'
+        mode "0750"
+        to node['dnsmasq']['data_volume']["logs_dir"]
     end
 
     kubernetes_dns = nil

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -118,3 +118,9 @@ bash "unzip Consul" do
         chmod 750 #{node['consul']['bin_dir']}/consul
     EOH
 end
+
+directory node['dnsmasq']['home'] do
+    owner 'root'
+    group 'root'
+    mode 0750
+end

--- a/templates/default/config/master.hcl.erb
+++ b/templates/default/config/master.hcl.erb
@@ -30,3 +30,5 @@ telemetry = {
    prometheus_retention_time = "<%= node['consul']['metrics']['prometheus_retention_time'] %>",
    disable_hostname = true
 }
+log_file = "<%= node['consul']['logs_dir'] %>/consul"
+log_rotate_max_files = 7

--- a/templates/default/config/slave.hcl.erb
+++ b/templates/default/config/slave.hcl.erb
@@ -25,3 +25,5 @@ telemetry = {
    prometheus_retention_time = "<%= node['consul']['metrics']['prometheus_retention_time'] %>",
    disable_hostname = true
 }
+log_file = "<%= node['consul']['logs_dir'] %>/consul"
+log_rotate_max_files = 7

--- a/templates/default/dnsmasq-conf.erb
+++ b/templates/default/dnsmasq-conf.erb
@@ -7,6 +7,7 @@ no-resolv
 bind-interfaces
 listen-address=<%= @dnsmasq_ip %>
 server=/<%= node['consul']['domain'] %>/127.0.0.1#8600
+log-facility=<%= node['dnsmasq']['logs_dir'] %>/dnsmasq.log
 <% if !@kubernetes_dns.nil? -%>
 server=/<%= @kubernetes_domain_name %>/<%= @kubernetes_dns %>#53
 <% end -%>

--- a/templates/default/init/consul.service.erb
+++ b/templates/default/init/consul.service.erb
@@ -18,6 +18,8 @@ KillMode=process
 Restart=on-failure
 LimitNOFILE=65536
 RestartSec=1
+StandardOutput=null
+StandardError=null
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
* [HWORKS-649] Use log files for Consul and dnsmasq instead of stdout/systemd

* [HWORKS-649] Fix typo

https://hopsworks.atlassian.net/browse/HWORKS-649